### PR TITLE
Fix BrokenPipe Error when streaming is aborted

### DIFF
--- a/music_assistant/controllers/stream.py
+++ b/music_assistant/controllers/stream.py
@@ -498,7 +498,7 @@ class StreamController:
                 # HANDLE FIRST PART OF TRACK
                 if not chunk and bytes_written == 0 and is_last_chunk:
                     # stream error: got empy first chunk
-                    self.logger.warning("Stream error on track %s", queue_track.item_id)
+                    self.logger.warning("Stream error on %s", queue_track.uri)
                     # prevent player queue get stuck by just skipping to the next track
                     queue_track.duration = 0
                     continue

--- a/music_assistant/controllers/stream.py
+++ b/music_assistant/controllers/stream.py
@@ -179,7 +179,7 @@ class StreamController:
                 # write eof when last packet is received
                 sox_proc.write_eof()
 
-            self.mass.create_task(writer)
+            sox_proc.attach_task(writer())
 
             # read bytes from final output
             async for audio_chunk in sox_proc.iterate_chunks():

--- a/music_assistant/helpers/audio.py
+++ b/music_assistant/helpers/audio.py
@@ -539,7 +539,7 @@ async def get_sox_args_for_pcm_stream(
     if not sox_present:
         if not ffmpeg_present:
             raise AudioError(
-                "FFmpeg binary is missing from system."
+                "FFmpeg binary is missing from system. "
                 "Please install ffmpeg on your OS to enable playback.",
             )
         # collect input args

--- a/music_assistant/helpers/process.py
+++ b/music_assistant/helpers/process.py
@@ -134,7 +134,7 @@ class AsyncProcess:
         return await self._proc.communicate(input_data)
 
     def attach_task(self, coro: Coroutine) -> None:
-        """Attach given coro func as reader/writer task so properly cancel it when needed."""
+        """Attach given coro func as reader/writer task to properly cancel it when needed."""
         self._attached_task = asyncio.create_task(coro)
 
 


### PR DESCRIPTION
Due to a race condition a BrokenPipe error may be raised when streaming is aborted (or user skips to the next track).
This should be fixed with this changes.