### PR TITLE
Fix: Stop playback at end of queue properly

### DIFF
--- a/music_assistant/controllers/stream.py
+++ b/music_assistant/controllers/stream.py
@@ -147,7 +147,7 @@ class StreamController:
         except QueueEmpty:
             # send stop here to prevent the player from retrying over and over
             await queue.stop()
-            # send 10 seconds of silence to allow the player to
+            # send some silence to allow the player to process the stop request
             result = create_wave_header(duration=10)
             result += b"\0" * 1764000
             return web.Response(status=200, body=result, content_type="audio/wav")

--- a/music_assistant/controllers/stream.py
+++ b/music_assistant/controllers/stream.py
@@ -144,6 +144,8 @@ class StreamController:
         try:
             start_streamdetails = await queue.queue_stream_prepare()
         except QueueEmpty:
+            # send stop here to prevent the player from retruying over and over
+            await queue.stop()
             return web.Response(status=404)
 
         resp = web.StreamResponse(

--- a/music_assistant/models/player_queue.py
+++ b/music_assistant/models/player_queue.py
@@ -723,7 +723,7 @@ class PlayerQueue:
 
     async def queue_stream_prepare(self) -> StreamDetails:
         """Call when queue_streamer is about to start playing."""
-        start_from_index = self._next_start_index or 0
+        start_from_index = self._next_start_index
         try:
             next_item = self._items[start_from_index]
         except (IndexError, TypeError) as err:
@@ -737,7 +737,7 @@ class PlayerQueue:
 
     async def queue_stream_start(self) -> int:
         """Call when queue_streamer starts playing the queue stream."""
-        start_from_index = self._next_start_index or 0
+        start_from_index = self._next_start_index
         self._current_item_elapsed_time = 0
         self._current_index = start_from_index
         self._start_index = start_from_index
@@ -754,12 +754,9 @@ class PlayerQueue:
 
     def get_next_index(self, index: int) -> int | None:
         """Return the next index or None if no more items."""
-        if not self._items:
+        if not self._items or index is None:
             # queue is empty
             return None
-        if index is None:
-            # guard just in case
-            return 0
         if self.settings.repeat_mode == RepeatMode.ONE:
             return index
         if len(self._items) > (index + 1):


### PR DESCRIPTION
- Make sure that a player should stop playback when we have no more tracks in queue.
- Do not repeat the queue's last track when the queue is at the end (and repeat disabled)