### PR TITLE
Fix artist not marked as 'in library' when exists on multiple providers

### DIFF
--- a/music_assistant/models/config.py
+++ b/music_assistant/models/config.py
@@ -24,7 +24,7 @@ class MusicProviderConfig:
     def __post_init__(self):
         """Call after init."""
         # create a default (hopefully unique enough) id from type + username/path
-        if not self.id:
+        if not self.id and (self.path or self.username):
             prov_id = f"{self.type.value}_"
             base_str = (self.path or self.username).lower()
             prov_id += (


### PR DESCRIPTION
Fixes the (race) condition where an artist exists on both disk (file provider) and a streaming provider with an endresult that the artist did not get marked as "in library" (which is a global preference of a media item, regardless of how many providers).
This forces the media item as in library from the filesystem scan and it has a guard on the streaming provider sync to not remove an item from the library if there are other providers attached to the same provider.