### PR TITLE
Support for album having multiple artists

### DIFF
--- a/music_assistant/controllers/music/albums.py
+++ b/music_assistant/controllers/music/albums.py
@@ -192,7 +192,7 @@ class AlbumsController(MediaControllerBase[Album]):
                     "year": album.year or cur_item.year,
                     "upc": album.upc or cur_item.upc,
                     "album_type": album_type.value,
-                    "artist": json_serializer(album_artists) or None,
+                    "artists": json_serializer(album_artists) or None,
                     "metadata": json_serializer(metadata),
                     "provider_ids": json_serializer(provider_ids),
                 },

--- a/music_assistant/controllers/music/providers/qobuz.py
+++ b/music_assistant/controllers/music/providers/qobuz.py
@@ -460,10 +460,7 @@ class QobuzProvider(MusicProvider):
             )
         )
 
-        if artist_obj:
-            album.artist = artist_obj
-        else:
-            album.artist = await self._parse_artist(album_obj["artist"])
+        album.artist = await self._parse_artist(artist_obj or album_obj["artist"])
         if (
             album_obj.get("product_type", "") == "single"
             or album_obj.get("release_type", "") == "single"

--- a/music_assistant/controllers/music/providers/spotify.py
+++ b/music_assistant/controllers/music/providers/spotify.py
@@ -320,10 +320,8 @@ class SpotifyProvider(MusicProvider):
         album = Album(
             item_id=album_obj["id"], provider=self.type, name=name, version=version
         )
-        for artist in album_obj["artists"]:
-            album.artist = await self._parse_artist(artist)
-            if album.artist:
-                break
+        for artist_obj in album_obj["artists"]:
+            album.artists.append(await self._parse_artist(artist_obj))
         if album_obj["album_type"] == "single":
             album.album_type = AlbumType.SINGLE
         elif album_obj["album_type"] == "compilation":

--- a/music_assistant/models/media_items.py
+++ b/music_assistant/models/media_items.py
@@ -245,10 +245,22 @@ class Album(MediaItem):
     media_type: MediaType = MediaType.ALBUM
     version: str = ""
     year: Optional[int] = None
-    artist: Union[Artist, ItemMapping, None] = None
+    artists: List[Union[Artist, ItemMapping]] = field(default_factory=list)
     album_type: AlbumType = AlbumType.UNKNOWN
     upc: Optional[str] = None
     musicbrainz_id: Optional[str] = None  # release group id
+
+    @property
+    def artist(self) -> Artist | ItemMapping | None:
+        """Return (first) artist of album."""
+        if self.artists:
+            return self.artists[0]
+        return None
+
+    @artist.setter
+    def artist(self, artist: Union[Artist, ItemMapping]) -> None:
+        """Set (first/only) artist of album."""
+        self.artists = [artist]
 
     def __hash__(self):
         """Return custom hash."""


### PR DESCRIPTION
- Enable support that an album can have multiple artists
- Including backwards compatibility
- Including database migration
- No rescan of existing media, a simple "refresh" on an album will reveal the additional artist(s)
