### PR TITLE
Fix default album fallback image for tracks

### DIFF
--- a/music_assistant/models/media_items.py
+++ b/music_assistant/models/media_items.py
@@ -299,6 +299,16 @@ class Track(MediaItem):
         """Return custom hash."""
         return hash((self.provider, self.item_id))
 
+    @property
+    def image(self) -> str | None:
+        """Return (first/random) image/thumb from metadata (if any)."""
+        if image := super().image:
+            return image
+        # fallback to album image
+        if self.album:
+            return self.album.image
+        return None
+
 
 @dataclass
 class Playlist(MediaItem):


### PR DESCRIPTION
Use album image by default if the track has no image itself