### PR TITLE
Allow more aggressive buffering by players that require it

### DIFF
--- a/music_assistant/music_providers/spotify.py
+++ b/music_assistant/music_providers/spotify.py
@@ -318,7 +318,7 @@ class SpotifyProvider(MusicProvider):
             args += ["--ap-port", "12345"]
         bytes_sent = 0
         async with AsyncProcess(args) as librespot_proc:
-            async for chunk in librespot_proc.iterate_chunks():
+            async for chunk in librespot_proc.iter_any():
                 yield chunk
                 bytes_sent += len(chunk)
 
@@ -328,7 +328,7 @@ class SpotifyProvider(MusicProvider):
             # retry with ap-port set to invalid value, which will force fallback
             args += ["--ap-port", "12345"]
             async with AsyncProcess(args) as librespot_proc:
-                async for chunk in librespot_proc.iterate_chunks():
+                async for chunk in librespot_proc.iter_any(64000):
                     yield chunk
             self._ap_workaround = True
 


### PR DESCRIPTION
For example cast players (especially with Hires audio) want to buffer ahead, allow this without breaking the scenario where the audio source itself is throttled (streaming providers like YT Music)