### PR TITLE
Extend support for plain URL's

### DIFF
--- a/music_assistant/controllers/metadata/__init__.py
+++ b/music_assistant/controllers/metadata/__init__.py
@@ -102,6 +102,9 @@ class MetaDataController:
         for track in await self.mass.music.playlists.tracks(
             playlist.item_id, playlist.provider
         ):
+            if track.media_type != MediaType.TRACK:
+                # filter out radio items
+                continue
             if track.metadata.genres:
                 playlist.metadata.genres.update(track.metadata.genres)
             elif track.album and track.album.metadata.genres:
@@ -221,7 +224,8 @@ class MetaDataController:
     ) -> bytes | str:
         """Get/create thumbnail image for path (image url or local path)."""
         # check if we already have this cached in the db
-        match = {"path": path, "size": size}
+        match_path = path.split("?")[0].split("&")[0]
+        match = {"path": match_path, "size": size}
         if result := await self.mass.database.get_row(TABLE_THUMBS, match):
             thumbnail = result["data"]
         else:

--- a/music_assistant/controllers/music/__init__.py
+++ b/music_assistant/controllers/music/__init__.py
@@ -232,6 +232,9 @@ class MusicController:
     ) -> MediaItemType:
         """Get single music item by id and media type."""
         assert provider or provider_id, "provider or provider_id must be supplied"
+        if provider == ProviderType.URL or provider_id == "url":
+            # handle special case of 'URL' MusicProvider which allows us to play regular url's
+            return await self.get_provider(ProviderType.URL).parse_item(item_id)
         ctrl = self.get_controller(media_type)
         return await ctrl.get(
             provider_item_id=item_id,

--- a/music_assistant/helpers/uri.py
+++ b/music_assistant/helpers/uri.py
@@ -20,6 +20,11 @@ def parse_uri(uri: str) -> Tuple[MediaType, ProviderType, str]:
             media_type_str = uri.split("/")[3]
             media_type = MediaType(media_type_str)
             item_id = uri.split("/")[4].split("?")[0]
+        elif uri.startswith("http://") or uri.startswith("https://"):
+            # Translate a plain URL to the URL provider
+            provider = ProviderType.URL
+            media_type = MediaType.UNKNOWN
+            item_id = uri
         elif "://" in uri:
             # music assistant-style uri
             # provider://media_type/item_id

--- a/music_assistant/models/enums.py
+++ b/music_assistant/models/enums.py
@@ -11,7 +11,6 @@ class MediaType(Enum):
     TRACK = "track"
     PLAYLIST = "playlist"
     RADIO = "radio"
-    URL = "url"
     FOLDER = "folder"
     UNKNOWN = "unknown"
 
@@ -29,6 +28,23 @@ class MediaQuality(IntEnum):
     LOSSLESS_HI_RES_2 = 21  # 88.2/96khz 24 bits HI-RES
     LOSSLESS_HI_RES_3 = 22  # 176/192khz 24 bits HI-RES
     LOSSLESS_HI_RES_4 = 23  # above 192khz 24 bits HI-RES
+
+    @classmethod
+    def from_file_type(cls, file_type: str) -> "MediaQuality":
+        """Try to parse MediaQuality from file type/extension."""
+        if "mp3" in file_type:
+            return MediaQuality.LOSSY_MP3
+        if "ogg" in file_type:
+            return MediaQuality.LOSSY_OGG
+        if "aac" in file_type:
+            return MediaQuality.LOSSY_AAC
+        if "m4a" in file_type:
+            return MediaQuality.LOSSY_M4A
+        if "flac" in file_type:
+            return MediaQuality.LOSSLESS
+        if "wav" in file_type:
+            return MediaQuality.LOSSLESS
+        return MediaQuality.UNKNOWN
 
 
 class LinkType(Enum):

--- a/music_assistant/models/music_provider.py
+++ b/music_assistant/models/music_provider.py
@@ -157,11 +157,11 @@ class MusicProvider:
 
     async def library_add(self, prov_item_id: str, media_type: MediaType) -> bool:
         """Add item to provider's library. Return true on succes."""
-        raise NotImplementedError
+        return True
 
     async def library_remove(self, prov_item_id: str, media_type: MediaType) -> bool:
         """Remove item from provider's library. Return true on succes."""
-        raise NotImplementedError
+        return True
 
     async def add_playlist_tracks(
         self, prov_playlist_id: str, prov_track_ids: List[str]
@@ -193,12 +193,11 @@ class MusicProvider:
             return await self.get_artist(prov_item_id)
         if media_type == MediaType.ALBUM:
             return await self.get_album(prov_item_id)
-        if media_type == MediaType.TRACK:
-            return await self.get_track(prov_item_id)
         if media_type == MediaType.PLAYLIST:
             return await self.get_playlist(prov_item_id)
         if media_type == MediaType.RADIO:
             return await self.get_radio(prov_item_id)
+        return await self.get_track(prov_item_id)
 
     async def browse(self, path: Optional[str] = None) -> List[MediaItemType]:
         """

--- a/music_assistant/models/queue_item.py
+++ b/music_assistant/models/queue_item.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 from mashumaro import DataClassDictMixin
 
-from music_assistant.models.enums import ContentType, MediaType, ProviderType
+from music_assistant.models.enums import MediaType
 from music_assistant.models.media_items import Radio, StreamDetails, Track
 
 
@@ -44,27 +44,6 @@ class QueueItem(DataClassDictMixin):
         if self.media_type == MediaType.RADIO:
             d.pop("duration")
         return d
-
-    @classmethod
-    def from_url(
-        cls,
-        url: str,
-        name: Optional[str] = None,
-        media_type: MediaType = MediaType.URL,
-    ) -> QueueItem:
-        """Create QueueItem from plain url (or local file)."""
-        return cls(
-            uri=url,
-            name=name or url.split("?")[0],
-            media_type=media_type,
-            streamdetails=StreamDetails(
-                provider=ProviderType.URL,
-                item_id=url,
-                content_type=ContentType.try_parse(url),
-                media_type=media_type,
-                data=url,
-            ),
-        )
 
     @classmethod
     def from_media_item(cls, media_item: Track | Radio):

--- a/music_assistant/music_providers/url.py
+++ b/music_assistant/music_providers/url.py
@@ -2,19 +2,36 @@
 from __future__ import annotations
 
 import os
-from typing import AsyncGenerator, List, Optional
+from typing import AsyncGenerator, List, Optional, Tuple
 
 from music_assistant.helpers.audio import (
     get_file_stream,
     get_http_stream,
     get_radio_stream,
 )
+from music_assistant.helpers.tags import AudioTags, parse_tags
 from music_assistant.models.config import MusicProviderConfig
-from music_assistant.models.enums import ContentType, MediaType, ProviderType
-from music_assistant.models.media_items import MediaItemType, StreamDetails
+from music_assistant.models.enums import (
+    ContentType,
+    ImageType,
+    MediaQuality,
+    MediaType,
+    ProviderType,
+)
+from music_assistant.models.media_items import (
+    Artist,
+    MediaItemImage,
+    MediaItemProviderId,
+    MediaItemType,
+    Radio,
+    StreamDetails,
+    Track,
+)
 from music_assistant.models.music_provider import MusicProvider
 
 PROVIDER_CONFIG = MusicProviderConfig(ProviderType.URL)
+
+# pylint: disable=arguments-renamed
 
 
 class URLProvider(MusicProvider):
@@ -25,6 +42,7 @@ class URLProvider(MusicProvider):
     _attr_available: bool = True
     _attr_supports_browse: bool = False
     _attr_supported_mediatypes: List[MediaType] = []
+    _full_url = {}
 
     async def setup(self) -> bool:
         """
@@ -34,6 +52,98 @@ class URLProvider(MusicProvider):
         """
         return True
 
+    async def get_track(self, prov_track_id: str) -> Track:
+        """Get full track details by id."""
+        return await self.parse_item(prov_track_id)
+
+    async def get_radio(self, prov_radio_id: str) -> Radio:
+        """Get full radio details by id."""
+        return await self.parse_item(prov_radio_id)
+
+    async def get_artist(self, prov_artist_id: str) -> Track:
+        """Get full artist details by id."""
+        artist = prov_artist_id
+        # this is here for compatibility reasons only
+        return Artist(
+            artist,
+            self.type,
+            artist,
+            provider_ids={
+                MediaItemProviderId(artist, self.type, self.id, available=False)
+            },
+        )
+
+    async def get_item(self, media_type: MediaType, prov_item_id: str) -> MediaItemType:
+        """Get single MediaItem from provider."""
+        if media_type == MediaType.ARTIST:
+            return await self.get_artist(prov_item_id)
+        if media_type == MediaType.TRACK:
+            return await self.get_track(prov_item_id)
+        if media_type == MediaType.RADIO:
+            return await self.get_radio(prov_item_id)
+        if media_type == MediaType.UNKNOWN:
+            return await self.parse_item(prov_item_id)
+        raise NotImplementedError
+
+    async def parse_item(
+        self, item_id_or_url: str, force_refresh: bool = False
+    ) -> Track | Radio:
+        """Parse plain URL to MediaItem of type Radio or Track."""
+        item_id, url, media_info = await self._get_media_info(
+            item_id_or_url, force_refresh
+        )
+        is_radio = media_info.get("icy-name") or not media_info.duration
+        if is_radio:
+            # treat as radio
+            media_item = Radio(
+                item_id=item_id,
+                provider=self.type,
+                name=media_info.get("icy-name") or media_info.title,
+            )
+        else:
+            media_item = Track(
+                item_id=item_id,
+                provider=self.type,
+                name=media_info.title,
+                duration=int(media_info.duration or 0),
+                artists=[
+                    await self.get_artist(artist) for artist in media_info.artists
+                ],
+            )
+
+        quality = MediaQuality.from_file_type(media_info.format)
+        media_item.provider_ids = {
+            MediaItemProviderId(item_id, self.type, self.id, quality=quality)
+        }
+        if media_info.has_cover_image:
+            media_item.metadata.images = [MediaItemImage(ImageType.THUMB, url, True)]
+        return media_item
+
+    async def _get_media_info(
+        self, item_id_or_url: str, force_refresh: bool = False
+    ) -> Tuple[str, str, AudioTags]:
+        """Retrieve (cached) mediainfo for url."""
+        if "?" in item_id_or_url or "&" in item_id_or_url:
+            # store the 'real' full url to be picked up later
+            # this makes sure that we're not storing any temporary data like auth keys etc
+            # a request for an url mediaitem always passes here first before streamdetails
+            url = item_id_or_url
+            item_id = item_id_or_url.split("?")[0].split("&")[0]
+            self._full_url[item_id] = url
+        else:
+            url = self._full_url.get(item_id_or_url, item_id_or_url)
+            item_id = item_id_or_url
+        cache_key = f"{self.type.value}.media_info.{item_id}"
+        # do we have some cached info for this url ?
+        cached_info = await self.mass.cache.get(cache_key)
+        if cached_info and not force_refresh:
+            media_info = AudioTags.parse(cached_info)
+        else:
+            # parse info with ffprobe (and store in cache)
+            media_info = await parse_tags(url)
+            await self.mass.cache.set(cache_key, media_info.raw)
+        return (item_id, url, media_info)
+
     async def search(
         self, search_query: str, media_types=Optional[List[MediaType]], limit: int = 5
     ) -> List[MediaItemType]:
@@ -42,12 +152,15 @@ class URLProvider(MusicProvider):
 
     async def get_stream_details(self, item_id: str) -> StreamDetails | None:
         """Get streamdetails for a track/radio."""
-        url = item_id
+        item_id, url, media_info = await self._get_media_info(item_id)
+        is_radio = media_info.get("icy-name") or not media_info.duration
         return StreamDetails(
-            provider=ProviderType.URL,
+            provider=self.type,
             item_id=item_id,
-            content_type=ContentType.try_parse(url),
-            media_type=MediaType.URL,
+            content_type=ContentType.try_parse(media_info.format),
+            media_type=MediaType.RADIO if is_radio else MediaType.TRACK,
+            sample_rate=media_info.sample_rate,
+            bit_depth=media_info.bits_per_sample,
             data=url,
         )
 


### PR DESCRIPTION
Make the URL Music provider a first class citizen.

- Grab metadata if a plain url (or file) is passed to play_media
- Determine if URL is a Track or Radio stream
- Allow URL's in local playlists