### PR TITLE
Improve Radio feature for mixed playlists

### DIFF
--- a/music_assistant/controllers/media/playlists.py
+++ b/music_assistant/controllers/media/playlists.py
@@ -34,10 +34,6 @@ class PlaylistController(MediaControllerBase[Playlist]):
     media_type = MediaType.PLAYLIST
     item_cls = Playlist
 
-    async def get_playlist_by_name(self, name: str) -> Playlist | None:
-        """Get in-library playlist by name."""
-        return await self.mass.database.get_row(self.db_table, {"name": name})
-
     async def tracks(
         self,
         item_id: str,

--- a/music_assistant/controllers/media/radio.py
+++ b/music_assistant/controllers/media/radio.py
@@ -22,10 +22,6 @@ class RadioController(MediaControllerBase[Radio]):
     media_type = MediaType.RADIO
     item_cls = Radio
 
-    async def get_radio_by_name(self, name: str) -> Radio | None:
-        """Get in-library radio by name."""
-        return await self.mass.database.get_row(self.db_table, {"name": name})
-
     async def versions(
         self,
         item_id: str,


### PR DESCRIPTION
prevent too many suggestions of one genre/style if the radio playlist contains a mix of multiple genres/styles.
this approach takes 5 suggestions from 1 track out of another 5 source tracks.
so the mix will still be 50/50 for original and suggested tracks but iterated in pairs of 5 instead of loading like 25 suggestions from 1 source track