### PR TITLE
Make Play media more flexible

### DIFF
--- a/music_assistant/controllers/media/artists.py
+++ b/music_assistant/controllers/media/artists.py
@@ -62,7 +62,7 @@ class ArtistsController(MediaControllerBase[Artist]):
             ],
         )
 
-    async def toptracks(
+    async def tracks(
         self,
         item_id: Optional[str] = None,
         provider: Optional[ProviderType] = None,
@@ -407,7 +407,7 @@ class ArtistsController(MediaControllerBase[Artist]):
             "Trying to match artist %s on provider %s", db_artist.name, provider.name
         )
         # try to get a match with some reference tracks of this artist
-        for ref_track in await self.toptracks(
+        for ref_track in await self.tracks(
             db_artist.item_id, db_artist.provider, artist=db_artist
         ):
             # make sure we have a full track

--- a/music_assistant/controllers/metadata/metadata.py
+++ b/music_assistant/controllers/metadata/metadata.py
@@ -156,7 +156,7 @@ class MetaDataController:
                     return musicbrainz_id
 
         # try again with matching on track isrc
-        ref_tracks = await self.mass.music.artists.toptracks(artist=artist)
+        ref_tracks = await self.mass.music.artists.tracks(artist=artist)
         for ref_track in ref_tracks:
             for isrc in ref_track.isrcs:
                 if musicbrainz_id := await self.musicbrainz.get_mb_artist_id(

--- a/music_assistant/models/enums.py
+++ b/music_assistant/models/enums.py
@@ -176,22 +176,37 @@ class ContentType(Enum):
 
 
 class QueueOption(Enum):
-    """Enum representation of the queue (play) options."""
+    """
+    Enum representation of the queue (play) options.
+
+    - PLAY -> Insert new item(s) in queue at the current position and start playing.
+    - REPLACE -> Replace entire queue contents with the new items and start playing from index 0.
+    - NEXT -> Insert item(s) after current playing/buffered item.
+    - REPLACE_NEXT -> Replace item(s) after current playing/buffered item.
+    - ADD -> Add new item(s) to the queue (at the end if shuffle is not enabled).
+    """
 
     PLAY = "play"
     REPLACE = "replace"
     NEXT = "next"
+    REPLACE_NEXT = "replace_next"
     ADD = "add"
-    RADIO = "radio"
 
 
 class CrossFadeMode(Enum):
-    """Enum with crossfade modes."""
+    """
+    Enum with crossfade modes.
 
-    DISABLED = "disabled"  # no crossfading at all
-    STRICT = "strict"  # do not crossfade tracks of same album
-    SMART = "smart"  # crossfade if possible (do not crossfade different sample rates)
-    ALWAYS = "always"  # all tracks - resample to fixed sample rate
+    - DISABLED: no crossfading at all
+    - STRICT: do not crossfade tracks of same album
+    - SMART: crossfade if possible (do not crossfade different sample rates)
+    - ALWAYS: all tracks - resample to fixed sample rate
+    """
+
+    DISABLED = "disabled"
+    STRICT = "strict"
+    SMART = "smart"
+    ALWAYS = "always"
 
 
 class RepeatMode(Enum):

--- a/music_assistant/models/player_queue.py
+++ b/music_assistant/models/player_queue.py
@@ -563,8 +563,6 @@ class PlayerQueue:
         insert_at_index: insert the item(s) at this index
         keep_remaining: keep the remaining items after the insert
         """
-        if not self.items:
-            return await self.load(queue_items)
 
         # keep previous/played items, append the new ones
         all_items = self._items[:insert_at_index] + queue_items
@@ -572,7 +570,7 @@ class PlayerQueue:
         # if keep_remaining, append the old previous items
         if keep_remaining:
             cur_index = self.index_in_buffer or self._current_index or 0
-            if insert_at_index == cur_index and len(self._items) > insert_at_index:
+            if insert_at_index == cur_index:
                 # current item is replaced with new
                 all_items += self._items[insert_at_index + 1 :]
             else:

--- a/music_assistant/models/player_queue.py
+++ b/music_assistant/models/player_queue.py
@@ -174,7 +174,7 @@ class PlayerQueue:
     async def play_media(
         self,
         media: str | List[str] | MediaItemType | List[MediaItemType],
-        queue_opt: QueueOption = QueueOption.PLAY,
+        option: QueueOption = QueueOption.PLAY,
         radio_mode: bool = False,
         passive: bool = False,
     ) -> str:
@@ -239,23 +239,23 @@ class PlayerQueue:
 
         # load the items into the queue
         cur_index = self.index_in_buffer or self._current_index or 0
-        if queue_opt == QueueOption.REPLACE:
+        if option == QueueOption.REPLACE:
             # replace: clear all items and replace with the new items
             await self.clear()
             await self.load(queue_items)
             if not passive:
                 await self.play_index(0)
-        elif queue_opt == QueueOption.NEXT:
+        elif option == QueueOption.NEXT:
             await self.load(queue_items, insert_at_index=cur_index + 1)
-        elif queue_opt == QueueOption.REPLACE_NEXT:
+        elif option == QueueOption.REPLACE_NEXT:
             await self.load(
                 queue_items, insert_at_index=cur_index + 1, keep_remaining=False
             )
-        elif queue_opt == QueueOption.PLAY:
+        elif option == QueueOption.PLAY:
             await self.load(queue_items, insert_at_index=cur_index)
             if not passive:
                 await self.play_index(0)
-        elif queue_opt == QueueOption.ADD:
+        elif option == QueueOption.ADD:
             await self.load(
                 queue_items,
                 insert_at_index=len(self._items) - 1,


### PR DESCRIPTION
Refactor Play media and queuing of items to support more flexible usecases.

- Radio mode is now a parameter instead of QueueOption
- Added "replace next" QueueOption to support keeping current index while changing all next items.
- Better shuffling of items